### PR TITLE
Fix transfer API

### DIFF
--- a/fisdemoaccount/src/main/resources/spring/camel-context.xml
+++ b/fisdemoaccount/src/main/resources/spring/camel-context.xml
@@ -30,7 +30,7 @@
             <put uri="profile/{acctid}">
                 <to uri="direct:createprofile"/>
             </put>
-            <post uri="transfer/{acctid}/">
+            <post uri="transfer/{acctid}">
                 <to uri="direct:dotransfer"/>
             </post>
         </rest>
@@ -42,9 +42,10 @@
         </route>
         <route id="transferroute">
             <from id="_from1" uri="direct:dotransfer"/>
+            <log id="_log1" message="Transfer ${headers.amt} from ${headers.acctid} to ${headers.recepid} "/>
             <transacted id="_transacted1">
-                <to id="_to4" uri="sql:update accounts set balance =  (select balance from accounts where id = :#acctid ) -:#amt where id =:#acctid?dataSource=dataSource"/>
-                <to id="_to5" uri="sql:update accounts set balance =  (select balance from accounts where id = :#recepid ) +:#amt where id =:#recepid?dataSource=dataSource"/>
+                <to id="_to4" uri="sql:update accounts set balance = balance -:#amt where id =:#acctid?dataSource=dataSource"/>
+                <to id="_to5" uri="sql:update accounts set balance = balance +:#amt where id =:#recepid?dataSource=dataSource"/>
                 <to id="_to6" uri="sql:select * from accounts where id=:#acctid?outputClass=com.redhat.myfispipeline.Accounts&amp;dataSource=dataSource&amp;outputType=SelectOne"/>
             </transacted>
         </route>

--- a/fisdemoaccount/src/main/resources/spring/camel-context.xml
+++ b/fisdemoaccount/src/main/resources/spring/camel-context.xml
@@ -42,7 +42,7 @@
         </route>
         <route id="transferroute">
             <from id="_from1" uri="direct:dotransfer"/>
-            <log id="_log1" message="Transfer ${headers.amt} from ${headers.acctid} to ${headers.recepid} "/>
+            <log id="_log99" message="Transfer ${headers.amt} from ${headers.acctid} to ${headers.recepid} "/>
             <transacted id="_transacted1">
                 <to id="_to4" uri="sql:update accounts set balance = balance -:#amt where id =:#acctid?dataSource=dataSource"/>
                 <to id="_to5" uri="sql:update accounts set balance = balance +:#amt where id =:#recepid?dataSource=dataSource"/>

--- a/fisdemoaggregator/pom.xml
+++ b/fisdemoaggregator/pom.xml
@@ -61,11 +61,6 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
     <!-- For Testing -->
 	<dependency>
 	    <groupId>org.apache.httpcomponents</groupId>

--- a/fisdemoaggregator/src/main/resources/spring/camel-context.xml
+++ b/fisdemoaggregator/src/main/resources/spring/camel-context.xml
@@ -64,14 +64,17 @@
         </route>
         <route id="gatewaytransfer">
             <from id="_from2" uri="direct:dotransfer"/>
-            <log id="_log2" message="do balance ${header.acctid} ${header.amt} ${header.recptid} ${header.moneysource}"/>
+            <log id="_log2" message="transfer from ${header.acctid} for ${header.amt} to ${header.recptid} using type ${header.moneysource}"/>
             <removeHeaders id="_removeHeaders2" pattern="Camel*"/>
             <choice id="_choice2">
                 <when id="_when2">
                     <simple>${header.moneysource} == 'bitcoin'</simple>
                     <log id="_log6" message="Bitcoin transfer "/>
+                    <setHeader headerName="CamelHttpMethod" id="_setHeader2">
+                        <constant>POST</constant>
+                    </setHeader>
                     <recipientList id="_recipientList3">
-                        <simple>http://fisblockchain-service/demos/bitcoinaccount/transfer/${header.acctid}/${header.amt}/${header.recptid}?bridgeEndpoint=true</simple>
+                        <simple>http://fisblockchain-service/demos/bitcoinaccount/transfer/${header.acctid}?bridgeEndpoint=true</simple>
                     </recipientList>
                     <convertBodyTo id="_convertBodyTo2" type="java.lang.String"/>
                     <log id="_log7" message="${body}"/>
@@ -81,15 +84,10 @@
                     <setHeader headerName="CamelHttpMethod" id="_setHeader2">
                         <constant>POST</constant>
                     </setHeader>
-                    <setHeader headerName="CamelHttpQuery" id="_setQueryParam1">
-                        <simple>?amt=${header.amt}&amp;recepid=${header.recptid}</simple>   
-                    </setHeader>                    
-                    <to id="account-transfer" uri="http://fisaccount-service/demos/account/transfer/#acctid?bridgeEndpoint=true"/>
-                    <!-->
                     <recipientList id="_recipientList4">
-                        <simple>http://fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true</simple>
+                        <!-- Note we only need to define the recepid in the payload below because it's a new query parameetr (i.e. not the same as recptid), amt carries over from headers in Exchange-->
+                        <simple>http://fisaccount-service/demos/account/transfer/${header.acctid}?recepid=${header.recptid}&amp;bridgeEndpoint=true</simple>
                     </recipientList>
-                    -->
                     <convertBodyTo id="_convertBodyTo4" type="java.lang.String"/>
                     <log id="_log7" message="${body}"/>
                 </otherwise>

--- a/fisdemoaggregator/src/main/resources/spring/camel-context.xml
+++ b/fisdemoaggregator/src/main/resources/spring/camel-context.xml
@@ -81,7 +81,7 @@
                     <setHeader headerName="CamelHttpMethod" id="_setHeader1">
                         <constant>POST</constant>
                     </setHeader>
-                    <to id="account-transfer" url="http://fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true"/>
+                    <to id="account-transfer" uri="http://fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true"/>
                     <!-->
                     <recipientList id="_recipientList4">
                         <simple>http://fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true</simple>

--- a/fisdemoaggregator/src/main/resources/spring/camel-context.xml
+++ b/fisdemoaggregator/src/main/resources/spring/camel-context.xml
@@ -81,7 +81,10 @@
                     <setHeader headerName="CamelHttpMethod" id="_setHeader2">
                         <constant>POST</constant>
                     </setHeader>
-                    <to id="account-transfer" uri="http://fisaccount-service/demos/account/transfer/#acctid?amt=#amt&amp;recepid=#recepid?bridgeEndpoint=true"/>
+                    <setHeader headerName="CamelHttpQuery" id="_setQueryParam1">
+                        <simple>?amt=${header.amt}&amp;recepid=${header.recptid}</simple>   
+                    </setHeader>                    
+                    <to id="account-transfer" uri="http://fisaccount-service/demos/account/transfer/#acctid?bridgeEndpoint=true"/>
                     <!-->
                     <recipientList id="_recipientList4">
                         <simple>http://fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true</simple>

--- a/fisdemoaggregator/src/main/resources/spring/camel-context.xml
+++ b/fisdemoaggregator/src/main/resources/spring/camel-context.xml
@@ -78,9 +78,15 @@
                 </when>
                 <otherwise id="_otherwise2">
                     <log id="_log8" message="Traditional banking"/>
+                    <setHeader headerName="CamelHttpMethod" id="_setHeader1">
+                        <constant>POST</constant>
+                    </setHeader>
+                    <to id="account-transfer" url="rest:post:fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true"/>
+                    <!-->
                     <recipientList id="_recipientList4">
-                        <simple>http://fisaccount-service/demos/account/transfer/${header.acctid}/${header.amt}/${header.recptid}?bridgeEndpoint=true</simple>
+                        <simple>http://fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true</simple>
                     </recipientList>
+                    -->
                     <convertBodyTo id="_convertBodyTo4" type="java.lang.String"/>
                     <log id="_log7" message="${body}"/>
                 </otherwise>

--- a/fisdemoaggregator/src/main/resources/spring/camel-context.xml
+++ b/fisdemoaggregator/src/main/resources/spring/camel-context.xml
@@ -81,7 +81,7 @@
                     <setHeader headerName="CamelHttpMethod" id="_setHeader1">
                         <constant>POST</constant>
                     </setHeader>
-                    <to id="account-transfer" url="rest:post:fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true"/>
+                    <to id="account-transfer" url="http://fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true"/>
                     <!-->
                     <recipientList id="_recipientList4">
                         <simple>http://fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true</simple>

--- a/fisdemoaggregator/src/main/resources/spring/camel-context.xml
+++ b/fisdemoaggregator/src/main/resources/spring/camel-context.xml
@@ -78,10 +78,10 @@
                 </when>
                 <otherwise id="_otherwise2">
                     <log id="_log8" message="Traditional banking"/>
-                    <setHeader headerName="CamelHttpMethod" id="_setHeader1">
+                    <setHeader headerName="CamelHttpMethod" id="_setHeader2">
                         <constant>POST</constant>
                     </setHeader>
-                    <to id="account-transfer" uri="http://fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true"/>
+                    <to id="account-transfer" uri="http://fisaccount-service/demos/account/transfer/#acctid?amt=#amt&amp;recepid=#recepid?bridgeEndpoint=true"/>
                     <!-->
                     <recipientList id="_recipientList4">
                         <simple>http://fisaccount-service/demos/account/transfer/${header.acctid}?amt=${header.amt}&amp;recepid=${header.recptid}?bridgeEndpoint=true</simple>

--- a/fisdemoblockchain/src/main/java/com/redhat/fisdemoblockchain/MockBitcoinApp.java
+++ b/fisdemoblockchain/src/main/java/com/redhat/fisdemoblockchain/MockBitcoinApp.java
@@ -61,12 +61,12 @@ public class MockBitcoinApp {
 		
 		if(acctBalance != null && recptBalance != null){
 			accounts.put(acctid, acctBalance-amt);
-			accounts.put(acctid, recptBalance+amt);
+			accounts.put(recptid, recptBalance+amt);
 		}else{
 			return "Transfer: ONE of the account NOT FOUND!";
 		}
 		ledger.transfer(acctid, amt, recptid);
-		return "Successfully transfered $"+amt+"from "+acctid+"to "+recptid+" remaining balance are: $"+(acctBalance-amt);
+		return "Successfully transfered $"+amt+" from "+acctid+" to "+recptid+" remaining balance are: $"+(acctBalance-amt);
 	}
 
 }

--- a/fisdemoblockchain/src/test/java/com/redhat/fisdemoblockchain/ApplicationTest.java
+++ b/fisdemoblockchain/src/test/java/com/redhat/fisdemoblockchain/ApplicationTest.java
@@ -60,6 +60,6 @@ public class ApplicationTest {
         ResponseEntity<String> transferResponse = restTemplate.postForEntity("/demos/bitcoinaccount/transfer/123456", headers ,String.class);
         
         assertThat(transferResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(transferResponse.getBody()).isEqualTo("\"Successfully transfered $30from 123456to 345678 remaining balance are: $2970\"");
+        assertThat(transferResponse.getBody()).isEqualTo("\"Successfully transfered $30 from 123456 to 345678 remaining balance are: $2970\"");
     }
 }


### PR DESCRIPTION
This is a new pull request that has been re-based on the current code and fixes all of the issues with the transfer API so it now works correctly for both traditional and bitcoin sources.  The following changes were made:

a. Use POST method when calling transfer methods on fisaccount and fisbitcoin

b. Remove the unneeded query parameters from the recepientlist, they are already in the Exchange from the original master. This was causing them to be doubled up and causing errors

c. Add the ```recepid``` header needed for fisaccount, this could also be fixed by changing fisaccount to take ```receptid``` instead. I can see this could be a typo but I opted for this fix instead, makes for a talking point.

d. For the bitcoin, it was putting the updated amount in the wrong account.